### PR TITLE
Add support for `prompt` param to login/authorize

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -205,7 +205,7 @@ class RPCClient extends EventEmitter {
    * @returns {Promise}
    * @private
    */
-  async authorize({ scopes, clientSecret, rpcToken, redirectUri } = {}) {
+  async authorize({ scopes, clientSecret, rpcToken, redirectUri, prompt } = {}) {
     if (clientSecret && rpcToken === true) {
       const body = await this.fetch('POST', '/oauth2/token/rpc', {
         data: new URLSearchParams({
@@ -219,6 +219,7 @@ class RPCClient extends EventEmitter {
     const { code } = await this.request('AUTHORIZE', {
       scopes,
       client_id: this.clientId,
+      prompt,
       rpc_token: rpcToken,
     });
 


### PR DESCRIPTION
Per the documentation here:

https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-authorization-url-example

This param allows clients to pass "none" to avoid re-prompting for
authorization every time the client connects.